### PR TITLE
feat: track active section with IntersectionObserver

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -12,19 +12,23 @@ export default function Navbar() {
 
   // Detectar la sección visible con IntersectionObserver
   useEffect(() => {
-    const handler = () => {
-      const scrollPos = window.scrollY;
-      let current = "inicio";
-      for (let section of SECTIONS) {
-        const el = document.getElementById(section.id);
-        if (el && el.offsetTop - 120 <= scrollPos) {
-          current = section.id;
-        }
-      }
-      setActive(current);
-    };
-    window.addEventListener("scroll", handler);
-    return () => window.removeEventListener("scroll", handler);
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActive(entry.target.id);
+          }
+        });
+      },
+      { threshold: 0.5 }
+    );
+
+    SECTIONS.forEach(({ id }) => {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    });
+
+    return () => observer.disconnect();
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- replace scroll listener with IntersectionObserver to track which section is active

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68910c417b40832cab28cfeba5a80a55